### PR TITLE
Add ss58 format for Anmol

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -592,6 +592,8 @@ ss58_address_format!(
 		(77, "manta", "Manta Network, standard account (*25519).")
 	CalamariAccount =>
 		(78, "calamari", "Manta Canary Network, standard account (*25519).")
+	Anmol =>
+		(92, "anmol", "Anmol standard account (*25519).")
 	PolkaSmith =>
 		(98, "polkasmith", "PolkaSmith Canary Network, standard account (*25519).")
 	PolkaFoundry =>
@@ -600,6 +602,8 @@ ss58_address_format!(
 		(101, "origintrail-parachain", "OriginTrail Parachain, ethereumm account (ECDSA).")
 	HeikoAccount =>
 		(110, "heiko", "Heiko, session key (*25519).")
+	Ibtida =>
+		(128, "ibtida", "Anmol testnet standard account (*25519).")
 	ParallelAccount =>
 		(172, "parallel", "Parallel, session key (*25519).")
 	SocialAccount =>


### PR DESCRIPTION
The [Anmol team](https://github.com/anmolnetwork/anmol-node) wishes to register the `92` prefix for our testnet. This is to easily identify addresses and to prevent re-use across our imminently-launching testnet and future mainnet.

Please let us know of any feedback and thank you for your time. 

